### PR TITLE
Fix auth error handling

### DIFF
--- a/docs/api/response-structure.md
+++ b/docs/api/response-structure.md
@@ -1,0 +1,15 @@
+# Response
+
+All endpoints will return an object of type `Response`. As a mandatory pattern,
+every single response must contain an attribute called status, which is an int
+representing a [status code]
+(https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).
+
+# Errors
+
+The API endpoints should not throw, instead, they should catch all of the errors
+and return a response with the proper status code and, additionally, a `message`
+attribute explaining what went wrong.
+
+_TODO_: Create and use custom type for responses / errors as well as defining
+all possible errors as an object of that type (similar to what nestjs did).

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db";
 import { users } from "@/app/api/users/schema";
 import { eq } from "drizzle-orm";
 import { generateIdFromEntropySize } from "lucia";
-import { NextResponse } from "next/server";
+import { redirect } from "next/navigation";
 
 export async function GET(request: Request): Promise<Response> {
   const url = new URL(request.url);
@@ -57,7 +57,7 @@ export async function GET(request: Request): Promise<Response> {
         sessionCookie.attributes,
       );
 
-      return NextResponse.redirect("http://localhost:3000/");
+      redirect("http://localhost:3000/");
     }
 
     // user does not exist or does not have google linked
@@ -88,7 +88,7 @@ export async function GET(request: Request): Promise<Response> {
       });
     }
 
-    return NextResponse.redirect("http://localhost:3000/");
+    return redirect("http://localhost:3000/");
   } catch (e) {
     if (e instanceof OAuth2RequestError)
       return Response.json({ status: 400, message: "Invalid code" });

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -15,8 +15,9 @@ export async function GET(request: Request): Promise<Response> {
   const codeVerifier = cookies().get("google_code_verifier")?.value ?? null;
 
   if (!code || !state || !storedState || state !== storedState || !codeVerifier)
-    return new Response("error", {
+    return Response.json({
       status: 400,
+      message: "Problem with google auth setup",
     });
 
   try {
@@ -75,6 +76,7 @@ export async function GET(request: Request): Promise<Response> {
         .set({ googleId: googleUser.sub })
         .where(eq(users.id, existingUser.id));
     } else {
+      // user does not exist
       const userId = generateIdFromEntropySize(10); // 16 characters long
 
       await db.insert(users).values({
@@ -88,14 +90,12 @@ export async function GET(request: Request): Promise<Response> {
 
     return NextResponse.redirect("http://localhost:3000/");
   } catch (e) {
-    if (e instanceof OAuth2RequestError) {
-      return new Response("invalid code", {
-        status: 400,
-      });
-    }
+    if (e instanceof OAuth2RequestError)
+      return Response.json({ status: 400, message: "Invalid code" });
 
-    return new Response(null, {
+    return Response.json({
       status: 500,
+      message: "Something went wrong with google login",
     });
   }
 }


### PR DESCRIPTION
Closes #6 

Although this does not implement custom object for errors, it does provide feedback to the frontend via the `status` (which represents the status code) and `message` attributes. It also adds a bit of documentation related to response structure.

It might make sense to change the success flow, which currently redirects the user to the next page, to simply return a similar object with a success status code. This would leave the redirecting logic up to the frontend. This should be discussed before deciding on how to do it.